### PR TITLE
Avoid problem (string,id) in switching templates

### DIFF
--- a/oomako
+++ b/oomako
@@ -119,8 +119,9 @@ def renderMako(template, model, id, data, uid=1):
 
     with closing(db.cursor()) as cursor:
         makoinput = templateRead(template)
-
-        for obj in pool.get(model).browse(cursor,uid,[id]):
+        #browse last param is OpenERP dict Context. The 'browse_reference' variable to True
+        #force get all references in object (even one2many fields)
+        for obj in pool.get(model).browse(cursor,uid,[id], {'browse_reference': True}):
             env = {
                 'user':pool.get('res.users').browse(cursor,uid,uid),
                 'db': dbcfg.database,


### PR DESCRIPTION
Al mòdul de PowerEmail, s'afegeix al Context la variable {'browse_reference': True}.
Com que l'oomako no utilitza el PowerEmail per fer el render de la plantilla, no afegia aquesta variable al contexte. Aquesta variable el que fa és que en camps one2many, afegeixi la referència al model i no el model coma id en format string.