### PR TITLE
Condicions Particulars (M1 01): fix multiple page error

### DIFF
--- a/input/report-condicionsParticularsM101.mako
+++ b/input/report-condicionsParticularsM101.mako
@@ -479,7 +479,7 @@ def get_pas01(cas):
         </div>
         <hr/>
 
-        %if polissa != objects[-1]:
+        %if cas != objects[-1]:
             <p style="page-break-after:always;"></p>
         %endif
 


### PR DESCRIPTION
En nou document de condicions particulars es diferencia de l'anterior en que utilitza un objecte `giscedata.switching` en comptes de `giscedata.polissa`. A l'hora d'adaptar-lo se'ns va oblidar canviar aquesta variable, el que provoca que sempre surtin 2 pàgines (la segona en blanc).