### PR TITLE
add rejection text in legal footer

### DIFF
--- a/input/common/legal_footer_with_rejection.mako
+++ b/input/common/legal_footer_with_rejection.mako
@@ -1,0 +1,30 @@
+<font size="1" style="color:grey">
+    <p>
+        <p>
+            [CA] <strong>Dret de desistiment.</strong> <br>Totes les persones consumidores de la cooperativa disposen de 14 dies naturals des de la data del contracte per desistir dels serveis. En cas que vulguis desistir, és necessari que ens notifiquis la teva decisió per correu electrònic a <a href="mailto:comercialitzacio@somenergia.coop">comercialitzacio@somenergia.coop</a>, o per correu postal a SOM ENERGIA SCCL c/ Pic de Peguera 11, 17003 Girona. Si vols, pots utilitzar el text de desistiment que tens <b><a href="https://docs.google.com/document/d/10CzheqAYQs5lwvKpJBkaiBEdsHZjY6TZoeBDN-mOfT0/edit">en aquesta plantilla</a></b>.<br>
+            <strong>Conseqüències del desistiment.</strong> <br>Et tornarem els pagaments que hagis fet, si és el cas, com a molt tard en 14 dies naturals a partir de la data en què ens comuniquis la teva decisió. Efectuarem el reemborsament, sense que això suposi cap despesa per part teva, seguint el mateix mètode de pagament que hagis utilitzat, a no ser que ens n'indiquis un altre. En cas que s'hagi activat el subministrament d'electricitat, hauràs d'abonar el consum corresponent als dies pels quals t'haguem prestat el servei.<br>
+            A Som Energia <strong>no tens cap obligació de permanència</strong>. En el moment que vulguis, pots canviar de companyia comercialitzadora. Som una cooperativa d'electricitat 100% renovable sense ànim de lucre i un dels nostres principis és oferir el preu més ajustat possible. No oferim ofertes especials, ni clàusules addicionals, ni lletra petita. La transparència, el bon tracte, uns preus ajustats, el treball per un canvi de model energètic, són alguns dels valors de Som Energia i el motiu pel qual tanta gent se suma al projecte i continua amb nosaltres sense cap clàusula de permanència.
+        </p>
+        <p>
+            Informació Bàsica de Protecció de Dades. Responsable:<br>
+            <strong>SOM ENERGIA SCCL</strong>. Finalitat: prestar-te els serveis que ens has sollicitat, atendre les teves sollicituds d’informació i enviar-te comunicacions comercials. Legitimació: Execució d’un contracte, Interès legítim del responsable o Consentiment de l’Interessat/interessada. Cessions: No es cediran les teves dades a tercers llevat obligació legal. <br>
+            Drets: Tens dret a accedir, rectificar i suprimir les dades, així com altres drets, indicats a la informació addicional, que pots exercir a l’adreça del responsable. Informació addicional: Pots consultar informació addicional i detallada sobre Protecció de Dades <a href="https://www.somenergia.coop/ca/avis-legal/#politica-privacitat">aquí</a>. <br>
+            Aquest missatge i els seus arxius adjunts van dirigits exclusivament al seu destinatari, podent contenir informació confidencial sotmesa a secret professional. No està permesa la seva reproducció o distribució sense la nostra autorització expressa. Si tu no ets la destinatària final si us plau elimina’l i informa’ns per aquesta via.
+        </p>
+    </p>
+    <br>
+    <br>
+    <p>
+        <p>
+            [ES] <b>Derecho de desistimiento.</b> Todas las personas consumidoras de la cooperativa disponen de 14 días naturales desde la fecha del contrato para desistir de los servicios. Si quieres desistir, es necesario que nos notifiques tu decisión por correo electrónico a <a href="mailto:comercializacion@somenergia.coop">comercializacion@somenergia.coop</a>, o por correo postal a SOM ENERGIA SCCL c/Pic de Peguera 11, 17003 Girona. Para hacerlo, puedes utilizar el texto que figura <b><a href="https://docs.google.com/document/d/1KOnlw370Fkv8VX8mw2qfC7zvPKnAmptcGsvXU-4tMCc/edit">en esta plantilla</a></b>. <br>
+            <b>Consecuencias del desistimiento.</b> Te devolveremos todos los pagos recibidos, si los hay, dentro de 14 días naturales a partir de la fecha en la que nos comuniques tu decisión. Efectuaremos dicho reembolso, sin que esto suponga ningún gasto para ti, utilizando el mismo medio de pago que hayas empleado para la transacción inicial, a no ser que nos indiques lo contrario. En caso de que ya se encuentre activo el suministro de electricidad, deberás abonarnos el consumo correspondiente a los días en que te hayamos prestado servicio. <br>
+            En Som Energia <b>no tienes obligación de permanencia.</b> Cuando quieras, puedes cambiar de compañia comercializadora. Somos una cooperativa 100% renovable sin ánimo de lucro y uno de nuestros principios es ofrecer el precio lo más ajustado posible. No ofrecemos ofertas especiales, ni cláusulas adicionales ni letra pequeña. La transparencia, el buen trato, unos precios ajustados, el trabajo para un cambio de modelo energético, son algunos de los valores de Som Energia y el motivo por el cual tanta gente se suma al proyecto y sigue con nosotros, sin ninguna cláusula de permanencia.
+        </p>
+        <p>
+            Información Básica de Protección de Datos. Responsable:<br>
+            <strong>SOM ENERGIA SCCL.</strong> Finalidad: prestarte los servicios que nos has solicitado, atender tus solicitudes de información y enviarte comunicaciones comerciales. Legitimación: Ejecución de contrato, Interés legítimo del responsable o Consentimiento del Interesado/a. Cesiones: No se cederán tus datos a terceros salvo obligación legal. <br>
+            Derechos: Tienes derecho a acceder, rectificar y suprimir los datos, así como otros derechos, indicados en la información adicional, que puedes ejercer en la dirección del responsable. Información adicional: Puedes consultar información adicional y detallada sobre Protección de Datos <a href="https://www.somenergia.coop/es/aviso-legal/#politica-privacidad">aquí</a>.<br>
+            Este mensaje y sus archivos adjuntos van dirigidos exclusivamente a su destinatario, pudiendo contener información confidencial sometida a secreto profesional. No está permitida su reproducción o distribución sin nuestra autorización expresa. Si tú no eres la destinataria final por favor elimínalo e informa por esta vía.
+        </p>
+    </p>
+</font>

--- a/input/common/legal_footer_with_rejection.mako.yaml
+++ b/input/common/legal_footer_with_rejection.mako.yaml
@@ -1,0 +1,7 @@
+cc: false
+to: ""
+subject_translations:
+  ca_ES: ""
+  es_ES: ""
+subject: ""
+bcc: ""


### PR DESCRIPTION
When someone changes the owner of a contract, the confirmation mail must have a legal text with the rejection options.
As this text will be placed in many other templates, we create a common template. 