### PR TITLE
Fix updates tariff prices to include taxes in contract

### DIFF
--- a/input/report-condicionsParticulars.mako
+++ b/input/report-condicionsParticulars.mako
@@ -347,7 +347,7 @@ def clean_text(text):
                 %for p in periodes_potencia:
                     <td style="width: 60px;" class="center">
                     %if polissa.llista_preu:
-                        <span class="center">${formatLang(get_atr_price(cursor, uid, polissa, p, 'tp', ctx)[0], digits=6)}</span>
+                        <span class="center">${formatLang(get_atr_price(cursor, uid, polissa, p, 'tp', ctx, with_taxes=True)[0], digits=6)}</span>
                     %else:
                             &nbsp;
                     %endif
@@ -366,7 +366,7 @@ def clean_text(text):
                 %for p in periodes_energia:
                     %if polissa.llista_preu:
                         <td style="width: 60px;" class="center">
-                            <span class="">${formatLang(get_atr_price(cursor, uid, polissa, p, 'te', ctx)[0], digits=6)}</span>
+                            <span class="">${formatLang(get_atr_price(cursor, uid, polissa, p, 'te', ctx, with_taxes=True)[0], digits=3)}</span>
                         </td>
                     %else:
                         <td style="width: 60px;" class="">
@@ -387,7 +387,7 @@ def clean_text(text):
                 %for p in periodes_energia:
                     %if polissa.llista_preu:
                         <td style="width: 60px;" class="center">
-                            <span class="">${formatLang(get_gkwh_atr_price(cursor, uid, polissa, p, ctx)[0], digits=6)}</span>
+                            <span class="">${formatLang(get_gkwh_atr_price(cursor, uid, polissa, p, ctx, with_taxes=True)[0], digits=3)}</span>
                         </td>
                     %else:
                         <td style="width: 60px;" class="">
@@ -410,7 +410,7 @@ def clean_text(text):
                         %if polissa.llista_preu:
                             %if polissa.autoconsumo != '00':
                                 <td style="width: 60px;" class="center">
-                                    <span>${formatLang(get_atr_price(cursor, uid, polissa, p, 'ac', ctx)[0], digits=6)}</span>
+                                    <span>${formatLang(get_atr_price(cursor, uid, polissa, p, 'ac', ctx)[0], digits=3)}</span>
                                 </td>
                             %else:
                                 <td style="width: 60px;">

--- a/input/report-condicionsParticularsM101.mako
+++ b/input/report-condicionsParticularsM101.mako
@@ -313,7 +313,7 @@ def get_pas01(cas):
                 %for p in periodes_potencia:
                     <td style="width: 60px;" class="center">
                     %if polissa.llista_preu:
-                        <span class="center">${formatLang(get_atr_price(cursor, uid, polissa, p, 'tp', ctx)[0], digits=6)}</span>
+                        <span class="center">${formatLang(get_atr_price(cursor, uid, polissa, p, 'tp', ctx, with_taxes=True)[0], digits=6)}</span>
                     %else:
                             &nbsp;
                     %endif
@@ -332,7 +332,7 @@ def get_pas01(cas):
                 %for p in periodes_energia:
                     %if polissa.llista_preu:
                         <td style="width: 60px;" class="center">
-                            <span class="">${formatLang(get_atr_price(cursor, uid, polissa, p, 'te', ctx)[0], digits=6)}</span>
+                            <span class="">${formatLang(get_atr_price(cursor, uid, polissa, p, 'te', ctx, with_taxes=True)[0], digits=3)}</span>
                         </td>
                     %else:
                         <td style="width: 60px;" class="">
@@ -353,7 +353,7 @@ def get_pas01(cas):
                 %for p in periodes_energia:
                     %if polissa.llista_preu:
                         <td style="width: 60px;" class="center">
-                            <span class="">${formatLang(get_gkwh_atr_price(cursor, uid, polissa, p, ctx)[0], digits=6)}</span>
+                            <span class="">${formatLang(get_gkwh_atr_price(cursor, uid, polissa, p, ctx, with_taxes=True)[0], digits=3)}</span>
                         </td>
                     %else:
                         <td style="width: 60px;" class="">
@@ -376,7 +376,7 @@ def get_pas01(cas):
                         %if polissa.llista_preu:
                             %if polissa.autoconsumo != '00':
                                 <td style="width: 60px;" class="center">
-                                    <span>${formatLang(get_atr_price(cursor, uid, polissa, p, 'ac', ctx)[0], digits=6)}</span>
+                                    <span>${formatLang(get_atr_price(cursor, uid, polissa, p, 'ac', ctx)[0], digits=3)}</span>
                                 </td>
                             %else:
                                 <td style="width: 60px;">

--- a/oomako
+++ b/oomako
@@ -141,7 +141,7 @@ def renderMakoPdf(template, report_id, id, data, uid=1):
     from contextlib import closing
 
     with closing(db.cursor()) as cursor:
-        ctx = {'browse_reference': True}
+        ctx = {}
         ir_obj = pool.get('ir.actions.report.xml')
         report_xml = ir_obj.browse(cursor, uid, report_id, context=ctx)
         report_xml.report_rml = None
@@ -155,6 +155,7 @@ def renderMakoPdf(template, report_id, id, data, uid=1):
 
         class report_webkit_html(report_sxw.rml_parse):
             def __init__(self, cursor, uid, name, context):
+                context['browse_reference'] = True
                 super(report_webkit_html, self).__init__(cursor, uid, name,
                                                          context=context)
                 self.localcontext.update({

--- a/testcases.yaml
+++ b/testcases.yaml
@@ -346,17 +346,47 @@
 #   model: giscedata.polissa
 #   reportXmlId: 527
 #   cases:
-#     ca_N: 240991
-#     catala_s_s: 207474
-#     catala_persona_f: 128907
+#       igic_vivenda: 158433
+#       igic_no_vivenda: 136877
+#       ca_N: 240991
+#       catala_s_s: 207474
+#       catala_persona_f: 128907
+#       20A_ca: 203092
+#       20A_es: 215948
+#       20DHA_ca: 208456
+#       20DHA_es: 58526
+#       20DHS_ca: 3744
+#       20DHS_es: 52378
+#       20A_e_g_es: 3847
+#       20DHA_g_ca: 86566
+#       20DHS_g_ca: 29616
+#       20DHS_g_es: 53737
+#       21A_ca: 78837
+#       21A_es: 171930
+#       21DHA_ca: 223631
+#       21DHA_es: 227116
+#       21DHS_ca: 49393
+#       21DHS_es: 60482
+#       30A_ca: 69977
+#       30A_es: 213676
+#       31A_ca: 12340
+#       31A_es: 192778
+#       20A_auto_directe_es: 262690
+#       20DHA_auto_g_es: 9398
+#       61A: 203034
 # reportCondicionsParticularsM101:
 #   template: input/report-condicionsParticularsM101.mako
 #   model: giscedata.switching
-#   reportXmlId: 999
+#   reportXmlId: 1469
 #   cases:
 #     ca_N: 274549
 #     catala_s_s: 282778
 #     catala_persona_f: 282717
+#     2_0DHA: 236801
+#     2_0A: 236941
+#     3_0A: 237057
+#     2_1A: 238934
+#     2_1DHA: 253218
 # avisCanviHora:
 #   template: input/correu-avisCanviHora.mako
 #   model: giscedata.polissa


### PR DESCRIPTION
Update `report-condicionsParticulars.mako` and `report-condicionsParticularsM101.mako` to include taxes in the tariff prices.

Fixes an issue when passing `browse_reference` to context.