### PR TITLE
Add tension on tension modification request

### DIFF
--- a/input/correu-activacioM105.mako
+++ b/input/correu-activacioM105.mako
@@ -150,7 +150,6 @@
         %else:
             &nbsp;&nbsp; <strong> Potència: ${pot_deseada} W</strong><br>
         %endif
-
         %if pas01 and pas01.solicitud_tensio:
             <%
                 tipus_tensio = None
@@ -158,10 +157,8 @@
                     tipus_tensio = "Trifàsica"
                 elif pas01.solicitud_tensio == 'M':
                     tipus_tensio = "Monofàsica"
-                endif
             %>
-            &nbsp;&nbsp; <strong> Tensió: ${tipus_tensio}</strong>
-            <br>
+            &nbsp;&nbsp; <strong> Tensió: ${tipus_tensio}</strong><br>
         %endif
 
         %if pas05.tipus_autoconsum != '00':
@@ -256,7 +253,6 @@
         %else:
             &nbsp;&nbsp;<strong> Potencia: ${pot_deseada} W</strong><br>
         %endif
-
         %if pas01 and pas01.solicitud_tensio:
             <%
                 tipus_tensio = None
@@ -264,10 +260,8 @@
                     tipus_tensio = "Trifásica"
                 elif pas01.solicitud_tensio == 'M':
                     tipus_tensio = "Monofásica"
-                endif
             %>
-            &nbsp;&nbsp; <strong> Tensión: ${tipus_tensio}</strong>
-            <br>
+            &nbsp;&nbsp; <strong> Tensión: ${tipus_tensio}</strong><br>
         %endif
 
         %if pas05.tipus_autoconsum != '00':

--- a/input/correu-activacioM105.mako
+++ b/input/correu-activacioM105.mako
@@ -27,6 +27,7 @@
 <%
     M105 = object.pool.get('giscedata.switching.m1.05')
     pas05 = object.step_ids[-1].pas_id if len(object.step_ids) > 0 else None
+    pas01 = object.step_ids[0].pas_id if len(object.step_ids) > 0 else None
 
     is_canvi_tit = object.step_ids[0].pas_id.sollicitudadm == 'S'
     is_pot_tar = object.step_ids[0].pas_id.sollicitudadm == 'N'
@@ -150,6 +151,19 @@
             &nbsp;&nbsp; <strong> Potència: ${pot_deseada} W</strong><br>
         %endif
 
+        %if pas01 and pas01.solicitud_tensio:
+            <%
+                tipus_tensio = None
+                if pas01.solicitud_tensio == 'T':
+                    tipus_tensio = "Trifàsica"
+                elif pas01.solicitud_tensio == 'M':
+                    tipus_tensio = "Monofàsica"
+                endif
+            %>
+            &nbsp;&nbsp; <strong> Tensió: ${tipus_tensio}</strong>
+            <br>
+        %endif
+
         %if pas05.tipus_autoconsum != '00':
             &nbsp;&nbsp;<strong> Autoconsum: </strong> <br>
             &nbsp;&nbsp;&nbsp;&nbsp; <strong> - Modalitat: ${autoconsum_description} </strong>
@@ -241,6 +255,19 @@
             ${pot_deseada}
         %else:
             &nbsp;&nbsp;<strong> Potencia: ${pot_deseada} W</strong><br>
+        %endif
+
+        %if pas01 and pas01.solicitud_tensio:
+            <%
+                tipus_tensio = None
+                if pas01.solicitud_tensio == 'T':
+                    tipus_tensio = "Trifásica"
+                elif pas01.solicitud_tensio == 'M':
+                    tipus_tensio = "Monofásica"
+                endif
+            %>
+            &nbsp;&nbsp; <strong> Tensión: ${tipus_tensio}</strong>
+            <br>
         %endif
 
         %if pas05.tipus_autoconsum != '00':

--- a/input/correu-validacioDadesModificacio.mako
+++ b/input/correu-validacioDadesModificacio.mako
@@ -71,6 +71,14 @@ if pas1:
         %else:
         - Potència desitjada: ${pot_deseada} W <br>
         %endif
+        %if pas1.solicitud_tensio:
+            - Tensió desitjada: 
+            %if pas1.solicitud_tensio == 'T':
+                Trifàsica
+            %elif pas1.solicitud_tensio == 'M':
+                Monofàsica
+            %endif
+        %endif
     </p>
     <p>
         Telèfon de contacte: ${cont_telefon} (recorda que aquest telèfon l'utilitzarà la distribuïdora de la teva zona per posar-se en contacte amb tu en el cas que sigui necessari).
@@ -116,6 +124,14 @@ Si ets una empresa i la teva distribuïdora és E-Distribución (antiga Endesa),
         ${pot_deseada}
         %else:
         - Potencia deseada: ${pot_deseada} W<br>
+        %endif
+        %if pas1.solicitud_tensio:
+            - Tensión deseada: 
+            %if pas1.solicitud_tensio == 'T':
+                Trifásica
+            %elif pas1.solicitud_tensio == 'M':
+                Monofásica
+            %endif
         %endif
     </p>
     <p>

--- a/input/correu-validacioDadesModificacio.mako
+++ b/input/correu-validacioDadesModificacio.mako
@@ -78,9 +78,8 @@ if pas1:
                     tipus_tensio = "Trifàsica"
                 elif pas1.solicitud_tensio == 'M':
                     tipus_tensio = "Monofàsica"
-                endif
             %>
-            - Tensió desitjada: ${tipus_tensio}
+        - Tensió desitjada: ${tipus_tensio}
         %endif
     </p>
     <p>
@@ -135,9 +134,8 @@ Si ets una empresa i la teva distribuïdora és E-Distribución (antiga Endesa),
                     tipus_tensio = "Trifásica"
                 elif pas1.solicitud_tensio == 'M':
                     tipus_tensio = "Monofásica"
-                endif
             %>
-            - Tensión deseada: ${tipus_tensio}
+        - Tensión deseada: ${tipus_tensio}
         %endif
     </p>
     <p>

--- a/input/correu-validacioDadesModificacio.mako
+++ b/input/correu-validacioDadesModificacio.mako
@@ -72,12 +72,15 @@ if pas1:
         - Potència desitjada: ${pot_deseada} W <br>
         %endif
         %if pas1.solicitud_tensio:
-            - Tensió desitjada: 
-            %if pas1.solicitud_tensio == 'T':
-                Trifàsica
-            %elif pas1.solicitud_tensio == 'M':
-                Monofàsica
-            %endif
+            <%
+                tipus_tensio = None
+                if pas1.solicitud_tensio == 'T':
+                    tipus_tensio = "Trifàsica"
+                elif pas1.solicitud_tensio == 'M':
+                    tipus_tensio = "Monofàsica"
+                endif
+            %>
+            - Tensió desitjada: ${tipus_tensio}
         %endif
     </p>
     <p>
@@ -126,12 +129,15 @@ Si ets una empresa i la teva distribuïdora és E-Distribución (antiga Endesa),
         - Potencia deseada: ${pot_deseada} W<br>
         %endif
         %if pas1.solicitud_tensio:
-            - Tensión deseada: 
-            %if pas1.solicitud_tensio == 'T':
-                Trifásica
-            %elif pas1.solicitud_tensio == 'M':
-                Monofásica
-            %endif
+            <%
+                tipus_tensio = None
+                if pas1.solicitud_tensio == 'T':
+                    tipus_tensio = "Trifásica"
+                elif pas1.solicitud_tensio == 'M':
+                    tipus_tensio = "Monofásica"
+                endif
+            %>
+            - Tensión deseada: ${tipus_tensio}
         %endif
     </p>
     <p>

--- a/testcases.yaml
+++ b/testcases.yaml
@@ -672,6 +672,10 @@
 #    20A_es: 1583  #par 11326
 #    30A_ca: 3632  #par 5366
 #    30A_es: 12696 #par 22212
+#    trifasica_ca: 272480
+#    trifasica_es: 271979
+#    monofasica_ca: 273113
+#    monofasica_es: 273331
 #
 #notificacioAcceptacioA3:
 #  template: input/correu-notificacioAcceptacioA3.mako
@@ -723,6 +727,10 @@
 #    2.1DHAto3.0A_ca: 50850
 #    3.0A_ca: 34800
 #    webform_contact_phone_different_to_polissa: 107487
+#    trifasica_ca: 272480
+#    trifasica_es: 271979
+#    monofasica_ca: 273113
+#    monofasica_es: 273331
 #
 #notificacioAltaAutoconsum:
 #  template: input/correu-notificacioAltaAutoconsum.mako


### PR DESCRIPTION
Poweremail templates `correu-validacioDadesModificacio.mako` and `correu-activacioM105.mako` are not showing the type of tension requested when the user requests a tension type change.

Updates both templates to show this value only if it's a tension modification request (`solicitud_tensio` field is set)