### PR TITLE
Fix incorrect tension in M1 05 template

### DIFF
--- a/input/correu-activacioM105.mako
+++ b/input/correu-activacioM105.mako
@@ -58,7 +58,7 @@
     pas01 = object.step_ids[0].pas_id if len(object.step_ids) > 0 else None
 
     tipus_tensio = False
-    if pas01 and pas01.solicitud_tensio:
+    if pas01 and pas01.solicitud_tensio and pas05.tensio_suministre:
         tipus_tensio = get_tension_type(object, pas05,
                                         object.polissa_ref_id.titular.lang)
 

--- a/input/correu-activacioM105.mako
+++ b/input/correu-activacioM105.mako
@@ -55,9 +55,12 @@
 <%
     M105 = object.pool.get('giscedata.switching.m1.05')
     pas05 = object.step_ids[-1].pas_id if len(object.step_ids) > 0 else None
+    pas01 = object.step_ids[0].pas_id if len(object.step_ids) > 0 else None
 
-    tipus_tensio = get_tension_type(object, pas05,
-                                    object.polissa_ref_id.titular.lang)
+    tipus_tensio = False
+    if pas01 and pas01.solicitud_tensio:
+        tipus_tensio = get_tension_type(object, pas05,
+                                        object.polissa_ref_id.titular.lang)
 
     is_canvi_tit = object.step_ids[0].pas_id.sollicitudadm == 'S'
     is_pot_tar = object.step_ids[0].pas_id.sollicitudadm == 'N'

--- a/input/correu-activacioM105.mako
+++ b/input/correu-activacioM105.mako
@@ -22,12 +22,42 @@
 
         return auto_consum + " - " + tipus_autoconsum[auto_consum]
 
+    def get_tension_type(object_, pas05, lang):
+        tension_obj = object_.pool.get('giscedata.tensions.tensio')
+
+        codi_cnmc = pas05.tensio_suministre
+        tension_ids = tension_obj.search(object_._cr, object_._uid,
+                                         [("cnmc_code", "=", codi_cnmc)])
+
+        if not tension_ids:
+            return False
+
+        tension_id = tension_ids[0]
+        tension_name = tension_obj.read(object_._cr, object_._uid,
+                                        tension_id, ['name']).get('name', '')
+
+        tension_text = False
+        if tension_name.startswith("3x"):
+            if lang == "ca_ES":
+                tension_text = "Trifàsica"
+            else:
+                tension_text = "Trifásica"
+        else:
+            if lang == "ca_ES":
+                tension_text = "Monofàsica"
+            else:
+                tension_text = "Monofásica"
+
+        return tension_text
+
 %>
 
 <%
     M105 = object.pool.get('giscedata.switching.m1.05')
     pas05 = object.step_ids[-1].pas_id if len(object.step_ids) > 0 else None
-    pas01 = object.step_ids[0].pas_id if len(object.step_ids) > 0 else None
+
+    tipus_tensio = get_tension_type(object, pas05,
+                                    object.polissa_ref_id.titular.lang)
 
     is_canvi_tit = object.step_ids[0].pas_id.sollicitudadm == 'S'
     is_pot_tar = object.step_ids[0].pas_id.sollicitudadm == 'N'
@@ -150,14 +180,7 @@
         %else:
             &nbsp;&nbsp; <strong> Potència: ${pot_deseada} W</strong><br>
         %endif
-        %if pas01 and pas01.solicitud_tensio:
-            <%
-                tipus_tensio = None
-                if pas01.solicitud_tensio == 'T':
-                    tipus_tensio = "Trifàsica"
-                elif pas01.solicitud_tensio == 'M':
-                    tipus_tensio = "Monofàsica"
-            %>
+        %if tipus_tensio:
             &nbsp;&nbsp; <strong> Tensió: ${tipus_tensio}</strong><br>
         %endif
 
@@ -253,14 +276,7 @@
         %else:
             &nbsp;&nbsp;<strong> Potencia: ${pot_deseada} W</strong><br>
         %endif
-        %if pas01 and pas01.solicitud_tensio:
-            <%
-                tipus_tensio = None
-                if pas01.solicitud_tensio == 'T':
-                    tipus_tensio = "Trifásica"
-                elif pas01.solicitud_tensio == 'M':
-                    tipus_tensio = "Monofásica"
-            %>
+        %if tipus_tensio:
             &nbsp;&nbsp; <strong> Tensión: ${tipus_tensio}</strong><br>
         %endif
 


### PR DESCRIPTION
El tipus de tensió (trifàsica o monofàsica) l'estava agafant del pas 01, el qual era incorrecte.

Per mostrar el tipus de tensió correctament s'havia d'agafar del pas 05, al camp `tensio_suministre`. Aquest camp té un codi especificat per la CNMC (taula 64 "Tensiones de suministro CIE y APM) que nosaltres guardem al model `giscedata.tensions.tensio`.

Per saber si aquests codis fan referencia a una tensió trifàsica s'ha de fer una cerca al model `giscedata.tensions.tensio` i comprovar que la seva descripció (camp `name`) començi per `3x` (per exemple: `3x230/400`), que és com s'està fent a l'ERP ara mateix.