### PR TITLE
Fix: new holder is getting the old contract number in email's subject

### DIFF
--- a/input/correu-validacioDadesOVCanviTitus.mako.yaml
+++ b/input/correu-validacioDadesOVCanviTitus.mako.yaml
@@ -1,6 +1,6 @@
 cc: false
 to: -- definit en codi --
 subject_translations: {}
-subject: 'Som Energia: Canvi de titular. Verificació de dades. Contracte ${object.cups_polissa_id.name}
-  / Cambio de titular. Verificación de datos. Contrato ${object.cups_polissa_id.name}'
+subject: 'Som Energia: Canvi de titular. Verificació de dades. Contracte ${object.polissa_ref_id.name}
+  / Cambio de titular. Verificación de datos. Contrato ${object.polissa_ref_id.name}'
 bcc: support.17062.b8d9f4469fa4d856@helpscout.net


### PR DESCRIPTION
A una incidència se'ns ha notificat que a l'assumpte de la notificació que s'envia al nou titular quan es fa una sol·licitud de canvi de titular surt el número de contracte antic.

La solució és agafar el número del contracte de `polissa_ref_id` en comptes de `cups_polissa_id`.