### PR TITLE
Fix solicitud tensión

### DIFF
--- a/input/correu-activacioM105.mako
+++ b/input/correu-activacioM105.mako
@@ -1,6 +1,7 @@
 <%!
     from mako.template import Template
     from datetime import datetime, timedelta
+    from gestionatr.defs import TABLA_64
 
     THREEPHASE = {
         'ca_ES': "Trifàsica",
@@ -33,20 +34,14 @@
         return auto_consum + " - " + tipus_autoconsum[auto_consum]
 
     def get_tension_type(object_, pas05, lang):
-        tension_obj = object_.pool.get('giscedata.tensions.tensio')
-
         codi_cnmc = pas05.tensio_suministre
-        tension_ids = tension_obj.search(object_._cr, object_._uid,
-                                         [("cnmc_code", "=", codi_cnmc)])
+        taula_cnmc = dict(TABLA_64)
+        tension_name = taula_cnmc.get(codi_cnmc, False)
 
-        if not tension_ids:
+        if not tension_name:
             return False
 
-        tension_id = tension_ids[0]
-        tension_name = tension_obj.read(object_._cr, object_._uid,
-                                        tension_id, ['name']).get('name', '')
-
-        if tension_name.startswith("3x"):
+        if tension_name.lower().startswith("3x"):
             return THREEPHASE[lang]
         return MONOPHASE[lang]
 
@@ -80,7 +75,7 @@
     polissa = object.polissa_ref_id if is_canvi_tit else object.cups_polissa_id
 
     tipus_tensio = False
-    if pas01 and pas01.solicitud_tensio and pas05.tensio_suministre:
+    if pas01 and pas01.solicitud_tensio == "S" and pas05.tensio_suministre:
         tipus_tensio = get_tension_type(object, pas05, polissa.titular.lang)
 
     p_obj = object.pool.get('res.partner')

--- a/input/correu-validacioDadesModificacio.mako
+++ b/input/correu-validacioDadesModificacio.mako
@@ -1,7 +1,31 @@
 <%
+from gestionatr.defs import TABLA_64
 
 pas1 = object.step_ids[0].pas_id if len(object.step_ids) > 0 else None
 
+THREEPHASE = {
+    'ca_ES': "Trifàsica",
+    'es_ES': "Trifásica"
+}
+
+MONOPHASE = {
+    'ca_ES': "Monofàsica",
+    'es_ES': "Monofásica"
+}
+
+def get_tension_type(object_, pas1, lang):
+    codi_cnmc = pas1.tensio_solicitada
+    taula_cnmc = dict(TABLA_64)
+    tension_name = taula_cnmc.get(codi_cnmc, False)
+
+    if not tension_name:
+        return False
+
+    if tension_name.lower().startswith("3x"):
+        return THREEPHASE[lang]
+    return MONOPHASE[lang]
+
+tipus_tensio = False
 if pas1:
 
     PasM101 = object.pool.get('giscedata.switching.m1.01')
@@ -23,6 +47,10 @@ if pas1:
           break
 
     pot_deseada = lineesDePotencia if tarifaATR == '3.0A' else potencia
+
+    if pas1.solicitud_tensio == "S" and pas1.tensio_solicitada:
+        lang = object.cups_polissa_id.titular.lang
+        tipus_tensio = get_tension_type(object, pas1, lang)
 %>
 
 <!doctype html>
@@ -71,14 +99,7 @@ if pas1:
         %else:
         - Potència desitjada: ${pot_deseada} W <br>
         %endif
-        %if pas1.solicitud_tensio:
-            <%
-                tipus_tensio = None
-                if pas1.solicitud_tensio == 'T':
-                    tipus_tensio = "Trifàsica"
-                elif pas1.solicitud_tensio == 'M':
-                    tipus_tensio = "Monofàsica"
-            %>
+        %if tipus_tensio:
         - Tensió desitjada: ${tipus_tensio}
         %endif
     </p>
@@ -123,14 +144,7 @@ if pas1:
         %else:
         - Potencia deseada: ${pot_deseada} W<br>
         %endif
-        %if pas1.solicitud_tensio:
-            <%
-                tipus_tensio = None
-                if pas1.solicitud_tensio == 'T':
-                    tipus_tensio = "Trifásica"
-                elif pas1.solicitud_tensio == 'M':
-                    tipus_tensio = "Monofásica"
-            %>
+        %if tipus_tensio:
         - Tensión deseada: ${tipus_tensio}
         %endif
     </p>


### PR DESCRIPTION
El camp `solicitud_tensio` abans tenia els valors `T` i `M`, per trifàsica i monofàsica respectivament. Amb l'ATR 2.0 aquest camp té els valors `S` i `N`: si el procés comporta un canvi de tensió aquest camp tindrà el valor `S`, si no tindrà el valor `N`.

A més, s'ha afegit un nou camp `tensio_solicitada` que tindrà un codi de la CNMC amb el tipus de tensió en concret. En el nostre cas utilitzarem les tensions normalitzades, és a dir `02` per monofàsica (1x230) i `05` per trifàsica (3x400).

També he modificat la plantilla `correu-activacioM105.mako` per a que agafi les el nom de les tensions de la variable `TABLA_64` (`from gestionatr.defs import TABLA_64`) en comptes d'agafar-lo del model `giscedata.tensions.tensio`, que no té tots els codis de la CNMC guardats.