### PR TITLE
Fix admin ov templates

### DIFF
--- a/input/correu-emailAdministradoraPerAdministradoraAssignacio.mako
+++ b/input/correu-emailAdministradoraPerAdministradoraAssignacio.mako
@@ -41,6 +41,12 @@ final = {
     False: {'ca_ES':'del següent contracte',
             'es_ES':'del siguiente contrato'}
 }
+this_contract_text = {
+    True: { 'ca_ES':'aquests contractes',
+            'es_ES':'estos contratos'},
+    False: {'ca_ES':'aquest contracte',
+            'es_ES':'este contrato'}
+}
 
 mail_lang = object.receptor.lang
 administradora = get_clean_name(object.receptor.name, object.receptor.vat, True)
@@ -63,6 +69,13 @@ T’enviem aquest correu per informar-te de les opcions d’administració de l�
     <li>Contracte ${contracte}: ${titular} t’ha assignat com a persona administradora per a ${permission} el contracte.</li>
 % endfor
 </ul>
+<br>
+Així doncs, podràs ${permission} ${this_contract_text[plural][mail_lang]} des de la teva Oficina Virtual, encara que no en siguis la persona titular. El fet que siguis administradora no implica que en siguis el/la responsable legal.
+<br>
+<br>
+Si no has accedit mai a l'Oficina Virtual, <a href="https://ca.support.somenergia.coop/article/109-com-puc-accedir-a-l-oficina-virtual">aquí</a> t’expliquem com fer-ho.
+<br>
+<br>
 Per a qualsevol dubte seguim en contacte.<br>
 <br>
 Equip de Som Energia<br>
@@ -78,6 +91,13 @@ Te enviamos este correo para informarte de las opciones de administración de la
     <li>Contrato ${contracte}: ${titular} te ha asignado como persona administradora para ${permission} el contrato.</li>
 % endfor
 </ul>
+<br>
+Por lo tanto, podrás ${permission} ${this_contract_text[plural][mail_lang]} desde tu Oficina Virtual, aunque no seas la persona titular. El hecho de que seas administradora no implica que seas el/la responsable legal.
+<br>
+<br>
+Si no has accedido nunca a la oficina virtual, <a href="https://es.support.somenergia.coop/article/165-como-puedo-acceder-a-la-oficina-virtual">aquí</a> te explicamos cómo hacerlo.
+<br>
+<br>
 Para cualquier duda seguimos en contacto. <br>
 <br>
 Equipo de Som Energia<br>

--- a/testcases.yaml
+++ b/testcases.yaml
@@ -1074,7 +1074,7 @@
 #emailAdministradoraPerTitularAssignacio:
 #  template: input/correu-emailAdministradoraPerTitularAssignacio.mako
 #  model: som.admin.notification
-#  poweremailId: 1
+#  poweremailId: som_polissa_administradora.email_assignacio_a_titular
 #  cases:
 #    es: 1
 #    singular: 6
@@ -1083,26 +1083,26 @@
 #emailAdministradoraPerTitularDesassignacio:
 #  template: input/correu-emailAdministradoraPerTitularDesassignacio.mako
 #  model: som.admin.notification
-#  poweremailId: 1
+#  poweremailId: som_polissa_administradora.email_desassignacio_a_titular
 #  cases:
 #    es: 3
 #    singular: 8
 #    varis: 15
 #
-#emailAdministradoraPerAdministradoraAssignacio:
-#  template: input/correu-emailAdministradoraPerAdministradoraAssignacio.mako
-#  model: som.admin.notification
-#  poweremailId: 1
-#  cases:
-#    ca: 2
-#    es: 5
-#    singular: 7
-#    dos: 11
+# emailAdministradoraPerAdministradoraAssignacio:
+#   template: input/correu-emailAdministradoraPerAdministradoraAssignacio.mako
+#   model: som.admin.notification
+#   poweremailId: som_polissa_administradora.email_assignacio_a_administradora
+#   cases:
+#     ca: 2
+#     es: 5
+#     singular: 7
+#     dos: 11
 #
 #emailAdministradoraPerAdministradoraDesassignacio:
 #  template: input/correu-emailAdministradoraPerAdministradoraDesassignacio.mako
 #  model: som.admin.notification
-#  poweremailId: 1
+#  poweremailId: som_polissa_administradora.email_desassignacio_a_administradora
 #  cases:
 #    ca: 4
 #    singular: 9


### PR DESCRIPTION
Afegeix 2 frases que faltaven a la plantilla `correu-emailAdministradoraPerAdministradoraAssignacio.mako`.

Afegeix els IDs semàntics per les 4 plantilles d'Administradora OV