### PR TITLE
Add support for semantic ID in report_xml templates and cases. Powere…

### DIFF
--- a/oomako
+++ b/oomako
@@ -121,6 +121,14 @@ def renderMako(template, model, id, data, uid=1):
         makoinput = templateRead(template)
         #browse last param is OpenERP dict Context. The 'browse_reference' variable to True
         #force get all references in object (even one2many fields)
+        ir_data_obj = pool.get('ir.model.data')
+        if not isinstance(id, int):
+            try:
+                id_data = ir_data_obj.search(cursor, uid, [('module', '=', id.split('.')[0]), ('name', '=', id.split('.')[1])])
+                id = ir_data_obj.read(cursor, uid, id_data[0], ['res_id'])['res_id']
+            except Exception as e:
+                print "ERROR: Id case incorrecte"
+                raise Exception("ERROR: Id case incorrecte: " + str(e))
         for obj in pool.get(model).browse(cursor,uid,[id], {'browse_reference': True}):
             env = {
                 'user':pool.get('res.users').browse(cursor,uid,uid),
@@ -141,8 +149,24 @@ def renderMakoPdf(template, report_id, id, data, uid=1):
     from contextlib import closing
 
     with closing(db.cursor()) as cursor:
+
         ctx = {}
         ir_obj = pool.get('ir.actions.report.xml')
+        ir_data_obj = pool.get('ir.model.data')
+        if not isinstance(report_id, int):
+            try:
+                id_data = ir_data_obj.search(cursor, uid, [('module','=',report_id.split('.')[0]), ('name','=',report_id.split('.')[1])])
+                report_id = ir_data_obj.read(cursor, uid, id_data[0], ['res_id'])['res_id']
+            except Exception as e:
+                print "ERROR: Id template incorrecte"
+                raise Exception("ERROR: Id template incorrecte: " + str(e))
+        if not isinstance(id, int):
+            try:
+                id_data = ir_data_obj.search(cursor, uid, [('module', '=', id.split('.')[0]), ('name', '=', id.split('.')[1])])
+                id = ir_data_obj.read(cursor, uid, id_data[0], ['res_id'])['res_id']
+            except Exception as e:
+                print "ERROR: Id case incorrecte"
+                raise Exception("ERROR: Id case incorrecte: " + str(e))
         report_xml = ir_obj.browse(cursor, uid, report_id, context=ctx)
         report_xml.report_rml = None
         report_xml.report_rml_content = None

--- a/testcases.yaml
+++ b/testcases.yaml
@@ -30,6 +30,13 @@
 #   cases:
 #     ca: 192
 #
+ nouSoci_destral:
+   template: input/correu-nouSoci.mako
+   model: somenergia.soci
+   poweremailId: som_polissa_soci.nou_soci_mail_webforms
+   cases:
+     ca: som_polissa_soci.soci_0001
+#
 ######################################################
 ## Facturació
 #
@@ -387,6 +394,17 @@
 #       20A_auto_directe_es: 262690
 #       20DHA_auto_g_es: 9398
 #       61A: 203034
+#
+#reportCondicionsParticulars_destral:
+#  template: input/report-condicionsParticulars.mako
+#  model: giscedata.polissa
+#  reportXmlId: 'giscedata_polissa.report_contracte'
+#  data:
+#    maxDiff: 0
+#    useErpMako: True
+#  cases:
+#    destral_ca: 'giscedata_polissa.polissa_0002'
+#
 # reportCondicionsParticularsM101:
 #   template: input/report-condicionsParticularsM101.mako
 #   model: giscedata.switching


### PR DESCRIPTION
# poweremail templates
*  Add support for semantic id in templates
*  Add support for semantic id in cases

# mako reports
*  Add support for semantic id in cases


# Unsolved
*  Still need a destral database created, perhaps auto-create like detral itself?
*  Languages
*  Create common cases by xml