### PR TITLE
[Do not merge yet] Adapt templates to D101 validation from OV (recuperat)

### DIFF
--- a/input/correu-notificacioAltaAutoconsum.mako
+++ b/input/correu-notificacioAltaAutoconsum.mako
@@ -103,7 +103,7 @@
             L'empresa de distribució elèctrica de la teva zona ens comunica que existeix una instal·lació d'autoproducció associada al punt de subministrament amb codi CUPS ${object.cups_id.name} corresponent a l’adreça ${object.cups_id.direccio}.
         </p>
         <p>
-            Pots accedir a través d'<a href="http://www.somenergia.coop/ca">aquest enllaç</a> a la teva oficina virtual i veure les característiques de la mateixa segons la informació que ens trasllada la distribuïdora.
+            Pots accedir a través d'<a href="http://oficinavirtual.somenergia.coop/ca">aquest enllaç</a> a la teva oficina virtual i veure les característiques de la mateixa segons la informació que ens trasllada la distribuïdora.
         </p>
         <p>
             Necessitem que acceptis o rebutgis, en el cas de que no estiguis d’acord amb la informació que ens indiquen, la comunicació que ens faciliten per poder continuar amb les gestions pertinents.
@@ -165,7 +165,7 @@
 	        La empresa de distribución eléctrica de tu zona nos comunica que existe una instalación de autoproducción asociada al punto de suministro con código CUPS ${object.cups_id.name} correspondiente a la dirección ${object.cups_id.direccio}.
         </p>
         <p>
-            Puedes acceder a través de <a href="http://www.somenergia.coop/es">este enlace</a> a tu oficina virtual y ver las características de la misma según la información que nos traslada la distribuidora.
+            Puedes acceder a través de <a href="http://oficinavirtual.somenergia.coop/es">este enlace</a> a tu oficina virtual y ver las características de la misma según la información que nos traslada la distribuidora.
         </p>
         <p>
             Necesitamos que aceptes o rechaces, en el caso de que no estés de acuerdo con la información que nos indican, la comunicación que nos facilitan para poder continuar con las gestiones pertinentes.

--- a/input/correu-notificacioAltaAutoconsum.mako
+++ b/input/correu-notificacioAltaAutoconsum.mako
@@ -24,33 +24,6 @@
         else:
             nom_titular = ''
         return nom_titular
-
-    def get_auto_code_name(object_, code):
-        if not code:
-            return "Codigo desconocido"
-        return get_description(code,'TABLA_127')
-
-    def get_auto_colective_name(object_, code):
-        switcher = {
-            True: "Si",
-            False: "No",
-        }
-        return switcher.get(code, "Codigo desconocido")
-
-    def get_auto_technologi_name(object_, code):
-        if not code:
-            return "Codigo desconocido"
-        return get_description(code,'TABLA_126')
-
-    def get_auto_type_name(object_, code):
-        if not code:
-            return "Codigo desconocido"
-        return get_description(code,'TABLA_129')
-
-    def get_auto_section_name(object_, code):
-        if not code:
-            return "Sin excedentes"
-        return get_description(code,'TABLA_128')
 %>
 <%
     partner_diferent = False
@@ -126,37 +99,25 @@
         <p>
             Hola${get_partner_name(object)},
         </p>
-	L’empresa de distribució elèctrica de la teva zona ens comunica que tens una instal·lació d’autoproducció associada al punt de subministrament amb codi CUPS ${object.cups_id.name} corresponent a l’adreça ${object.cups_id.direccio} amb les següents característiques segons els ha informat l’organisme competent de la teva comunitat autònoma:<br>
-	<br>
-	<b>Codi autoconsum:</b> ${d.cau}<br>
-	<b>Modalitat:</b> ${get_auto_code_name(object, d.seccio_registre)}<br>
-        <b>Tipus modalitat:</b> ${get_auto_section_name(object, d.subseccio)}<br>
-	<b>Instalació col·lectiva:</b> ${get_auto_colective_name(object, d.collectiu)}<br>
-        % if d.generadors[0].cil:
-	<b>CIL:</b> ${d.generadors[0].cil}<br>
-        % endif
-	<b>Tecnologia:</b> ${get_auto_technologi_name(object,d.generadors[0].tec_generador)}<br>
-	<b>Potència instal·lada:</b> ${d.generadors[0].pot_installada_gen} kW<br>
-	<b>Tipus instal·lació:</b> ${get_auto_type_name(object, d.generadors[0].tipus_installacio)}<br>
-	<b>Serveis auxiliars:</b> No<br>
-	<br>
-        % if partner_diferent:
-Ens informen també que la persona titular de la instal·lació generadora és una persona diferent de la titular del contracte.<br>
-	<br>
-        % endif
-Si és correcte cal que ens ho confirmis responent aquest mateix correu, indicant expressament que vols que demanem la modificació corresponent a la modalitat d’autoproducció triada a la distribuïdora per aplicar-ho al teu contracte i a la teva facturació mensual tal com s’estableix a les <a href="https://www.somenergia.coop/ca/condicions-del-contracte-de-som-energia/">CONDICIONS GENERALS</a>.<br>
-<br>
-En cas que es tracti d’una instal·lació registrada a la Comunitat Autònoma de Catalunya cal que també ens facis arribar el <b>Certificat d’Instal·lació de Generació</b> i el document de la declaració responsable complert o <b>RITSIC</b>, contestant aquest mateix correu. Si disposes del  <b>RAC</b> agraïrem que ens ho facis arribar també per ajudar-nos a contrastar la informació. <br>
-<br>
-El preu que estableix la cooperativa per els kWh d’energia excedentària és de 0,06359318€/kWh. Més info: <a href="https://ca.support.somenergia.coop/article/799-preu-compensacio-excedents-autoproduccio">Preu de compensació dels excedents en autoproducció</a>
-<br>
-	Si la informació que ens traslladen no és correcta, ens ho heu de notificar per comunicar-ho a la distribuïdora i també us heu d’adreçar a l’organisme pertinent de la vostra comunitat autònoma per tal que modifiquin/verifiquin la informació que els hi consta i tornin a passar la informació correctament a l’empresa distribuïdora.<br>
-	<br>
-	Quan ho hagin fet ens tornaran a enviar la informació actualitzada i t’informarem novament.<br>
-	<br>
-	Qualsevol dubte seguim en contacte.<br>
-	<br>
-	Salutacions,<br>
+        <p>
+            L'empresa de distribució elèctrica de la teva zona ens comunica que existeix una instal·lació d'autoproducció associada al punt de subministrament amb codi CUPS ${object.cups_id.name} corresponent a l’adreça ${object.cups_id.direccio}.
+        </p>
+        <p>
+            Pots accedir a través d'<a href="http://www.somenergia.coop/ca">aquest enllaç</a> a la teva oficina virtual i veure les característiques de la mateixa segons la informació que ens trasllada la distribuïdora.
+        </p>
+        <p>
+            Necessitem que acceptis o rebutgis, en el cas de que no estiguis d’acord amb la informació que ens indiquen, la comunicació que ens faciliten per poder continuar amb les gestions pertinents.
+        </p>
+        <p>
+            En cas que la informació sigui correcta, i hagis acceptat el tràmit, podràs demanar la modificació del contracte per aplicar la modalitat triada seguint els passos que et va indicant la oficina virtual. També et permet sol·licitar alguna altra modificació del contracte com pot ser la potència, tarifa o tensió del subministrament; si vols, pots aprofitar aquest mateix tràmit per fer-ho.
+        </p>
+        <p>
+            Recorda que tens més informació sobre l’autoconsum, el preu  de compensació, les modalitats, i els tràmits associats al centre d’ajuda de la nostra web dins l’apartat <a href="https://ca.support.somenergia.coop/category/777-autoproduccio">Autoproducció</a>. També pots consultar en el següent enllaç les <a href="https://www.somenergia.coop/ca/condicions-del-contracte-de-som-energia/">condicions generals</a> de contractació que vas acceptar en el moment de contractar amb Som Energia (la clàusula 8 tracta l’autoconsum).
+        </p>
+        <p>
+            Qualsevol dubte continuem en contacte.
+        </p>
+	    Salutacions,<br>
         <br>
         Equip de Som Energia<br>
         <a href="mailto:modifica@somenergia.coop">modifica@somenergia.coop</a><br>
@@ -194,38 +155,26 @@ El preu que estableix la cooperativa per els kWh d’energia excedentària és d
         </table>
         <p>
             Hola${get_partner_name(object)},
-	</p>
-	La empresa de distribución eléctrica de tu zona nos comunica que tienes una instalación de autoproducción asociada al punto de suministro con CUPS ${object.cups_id.name} de ${object.cups_id.direccio} con las siguientes características según les informó el organismo competente de tu comunidad autónoma:<br>
-	<br>
-	<b>Código autoconsumo:</b> ${d.cau}<br>
-	<b>Modalidad:</b> ${get_auto_code_name(object, d.seccio_registre)}<br>
-        <b>Tipo modalidad:</b> ${get_auto_section_name(object, d.subseccio)}<br>
-	<b>Instalación colectiva:</b> ${get_auto_colective_name(object, d.collectiu)}<br>
-        % if d.generadors[0].cil:
-	<b>CIL:</b> ${d.generadors[0].cil}<br>
-        % endif
-	<b>Tecnología:</b> ${get_auto_technologi_name(object, d.generadors[0].tec_generador)}<br>
-	<b>Potencia instalada:</b> ${d.generadors[0].pot_installada_gen} kW<br>
-	<b>Tipo instalación:</b> ${get_auto_type_name(object, d.generadors[0].tipus_installacio)}<br>
-	<b>Servicios auxiliares:</b> No<br>
-	<br>
-        % if partner_diferent:
-Nos informan también que la persona titular de la instalación generadora es una persona diferente a la titular del contrato.<br>
-	<br>
-        % endif
-	Si es correcto es necesario que nos lo confirmes respondiendo este mismo correo, indicando en él expresamente que deseas que solicitemos la modificación correspondiente a la modalidad de autoproducción elegida a la distribuidora para aplicarlo a tu contrato y en tu facturación mensual tal como se establece en las <a href="https://www.somenergia.coop/es/condiciones-del-contrato-de-som-energia/">CONDICIONES GENERALES</a>.<br>
-<br>
-En caso de que se trate de una instalación registrada en la Comunidad Autónoma de Cataluña es necesario también que nos hagas llegar el <b>Certificado de Instalación de Generación</b> y el documento de la Declaración responsable completo o <b>RITSIC</b>, contestando el mismo correo. Si dispones del  <b>RAC</b> agradeceremos que nos lo hagas llegar también para ayudarnos a contrastar la información. <br>
-<br>
-        El precio que establece la cooperativa para los kWh de energía excedentaria es de 0,06359318€/kWh. Más info: <a href="https://es.support.somenergia.coop/article/800-el-precio-de-compensacion-excedentes-autoproduccion">Precio de compensación de excedentes en autoproducción</a><br>
-	<br>
-	Si la información que nos trasladan no es correcta nos lo debes notificar para comunicarlo a la distribuidora y también debes dirigirte al organismo correspondiente de tu Comunidad Autónoma para que modifiquen/verifiquen la información que les consta y vuelvan a pasar la información correctamente a la empresa distribuidora.<br>
-	<br>
-	Cuando lo hayan hecho nos volverán a enviar la información actualizada y te informaremos nuevamente.<br>
-	<br>
-	Cualquier duda seguimos en contacto.<br>
-	<br>
-	Saludos,<br>
+	    </p>
+        <p>
+	        La empresa de distribución eléctrica de tu zona nos comunica que existe una instalación de autoproducción asociada al punto de suministro con código CUPS ${object.cups_id.name} correspondiente a la dirección ${object.cups_id.direccio}.
+        </p>
+        <p>
+            Puedes acceder a través de <a href="http://www.somenergia.coop/es">este enlace</a> a tu oficina virtual y ver las características de la misma según la información que nos traslada la distribuidora.
+        </p>
+        <p>
+            Necesitamos que aceptes o rechaces, en el caso de que no estés de acuerdo con la información que nos indican, la comunicación que nos facilitan para poder continuar con las gestiones pertinentes.
+        </p>
+        <p>
+            En caso de que la información sea correcta, y hayas aceptado el trámite, podrás pedir la modificación del contrato para aplicar la modalidad elegida siguiendo los pasos que te va indicando la oficina virtual. También te permite solicitar alguna otra modificación del contrato como puede ser la potencia, tarifa o tensión del suministro; si quieres, puedes aprovechar este mismo trámite para hacerlo.
+        </p>
+        <p>
+            Recuerda que tienes más información sobre el autoconsumo, el precio de compensación, las modalidades, y los trámites asociados en el centro de ayuda de nuestra web dentro del apartado <a href="https://es.support.somenergia.coop/category/779-autoproduccion">Autoproducción</a>. También puedes consultar en el siguiente enlace las <a href="https://www.somenergia.coop/es/condiciones-del-contrato-de-som-energia/">condiciones generales</a> de contratación que aceptaste en el momento de contratar con Som Energia (la cláusula 8 trata el autoconsumo).
+        </p>
+        <p>
+            Cualquier duda seguimos en contacto.
+        </p>
+        Saludos,<br>
         <br>
         Equipo de Som Energia<br>
         <a href="mailto:modifica@somenergia.coop">modifica@somenergia.coop</a><br>

--- a/input/correu-notificacioAltaAutoconsum.mako
+++ b/input/correu-notificacioAltaAutoconsum.mako
@@ -108,6 +108,11 @@
         <p>
             Necessitem que acceptis o rebutgis, en el cas de que no estiguis d’acord amb la informació que ens indiquen, la comunicació que ens faciliten per poder continuar amb les gestions pertinents.
         </p>
+        %if partner_diferent:
+        <p>
+            En el teu cas, ens informen també, que el titular de la instal·lació generadora és una altra persona, si no és correcte i ets tu mateix pots rebutjar la notificació i especificar-ho al motiu del rebuig.
+        </p>
+        %endif
         <p>
             En cas que la informació sigui correcta, i hagis acceptat el tràmit, podràs demanar la modificació del contracte per aplicar la modalitat triada seguint els passos que et va indicant la oficina virtual. També et permet sol·licitar alguna altra modificació del contracte com pot ser la potència, tarifa o tensió del subministrament; si vols, pots aprofitar aquest mateix tràmit per fer-ho.
         </p>
@@ -165,6 +170,11 @@
         <p>
             Necesitamos que aceptes o rechaces, en el caso de que no estés de acuerdo con la información que nos indican, la comunicación que nos facilitan para poder continuar con las gestiones pertinentes.
         </p>
+        %if partner_diferent:
+        <p>
+            En tu caso, nos informan también, que el titular de la instalación generadora es otra persona, si no es correcto y eres tú mismo puedes rechazar la notificación y especificarlo en el apartado de motivo de rechazo.
+        </p>
+        %endif
         <p>
             En caso de que la información sea correcta, y hayas aceptado el trámite, podrás pedir la modificación del contrato para aplicar la modalidad elegida siguiendo los pasos que te va indicando la oficina virtual. También te permite solicitar alguna otra modificación del contrato como puede ser la potencia, tarifa o tensión del suministro; si quieres, puedes aprovechar este mismo trámite para hacerlo.
         </p>

--- a/input/correu-notificacioAltaAutoconsum.mako.yaml
+++ b/input/correu-notificacioAltaAutoconsum.mako.yaml
@@ -2,8 +2,7 @@ cc: <% mail = '{}'.format(object.cups_polissa_id.administradora.address[0].email
   object.cups_polissa_id.administradora else '') %>  ${mail}
 to: ${object.cups_polissa_id.direccio_notificacio.email}
 subject_translations:
-  ca_ES: Confirmació dades inst.autoproducció CUPS ${object.cups_id.name}
-  es_ES: Confirmación datos inst.autoproducción CUPS ${object.cups_id.name}
-subject: Confirmació dades inst.autoproducció CUPS ${object.cups_id.name} / Confirmación
-  datos inst.autoproducción CUPS ${object.cups_id.name}
+  ca_ES: Informació de dades inst.autoproducció CUPS ${object.cups_id.name}
+  es_ES: Información de datos inst.autoproducción CUPS ${object.cups_id.name}
+subject: Informació de dades inst.autoproducció CUPS ${object.cups_id.name} / Información de datos inst.autoproducción CUPS ${object.cups_id.name}
 bcc: support.17062.b8d9f4469fa4d856@helpscout.net

--- a/input/correu-notificacioRebuigAutoconsum.mako
+++ b/input/correu-notificacioRebuigAutoconsum.mako
@@ -1,0 +1,140 @@
+<%!
+    from mako.template import Template
+
+    def render(text_to_render, object_):
+        templ = Template(text_to_render)
+        return templ.render_unicode(
+            object=object_,
+            format_exceptions=True
+    )
+
+    def get_partner_name(object_):
+        p_obj = object_.pool.get('res.partner')
+        if not object_.vat_enterprise():
+            nom_titular =' ' + p_obj.separa_cognoms(object_._cr, object_._uid, object_.cups_polissa_id.titular.name)['nom']
+        else:
+            nom_titular = ''
+        return nom_titular
+%>
+<%
+    polissa = object.cups_polissa_id
+
+    t_obj = object.pool.get('poweremail.templates')
+    md_obj = object.pool.get('ir.model.data')
+    template_id = md_obj.get_object_reference(
+                        object._cr, object._uid,  'som_poweremail_common_templates', 'common_template_legal_footer'
+                    )[1]
+
+    text_legal = render(t_obj.read(
+        object._cr, object._uid, [template_id], ['def_body_text'])[0]['def_body_text'],
+        object
+    )
+
+%>
+<!doctype html>
+<html>
+    <head>
+        <meta charset='utf-8'>
+    </head>
+    % if object.cups_polissa_id.titular.lang == "ca_ES":
+        ${correu_cat()}
+    % else:
+        ${correu_es()}
+    % endif
+    ${text_legal}
+</html>
+
+<%def name="correu_cat()">
+    <body>
+        <table width="100%" frame="below" bgcolor="#E8F1D4">
+            <tr>
+                <td height=2px>
+                    <font size=2><strong> Contracte Som Energia nº ${polissa.name}</strong></font>
+                </td>
+                <td valign=top rowspan="4" align="right">
+                    <img width='130' height='65' src="https://www.somenergia.coop/wp-content/uploads/2014/11/logo-somenergia.png">
+                </td>
+            </tr>
+            <tr>
+                <td height=2px>
+                    <font size=1> Adreça punt subministrament: ${object.cups_id.direccio}</font>
+                </td>
+            </tr>
+            <tr>
+                <td height=2px>
+                    <font size=1> Codi CUPS: ${object.cups_id.name}</font>
+                </td>
+            </tr>
+        </table>
+        <p>
+            Hola${get_partner_name(object)},
+        </p>
+        <p>
+            Ens ha arribat la notificació que no estàs d’acord amb les dades que ens ha passat l’empresa de distribució elèctrica referent a la teva instal·lació d’autoconsum associada al CUPS ${object.cups_id.name} amb direcció de subministrament ${object.cups_id.direccio}.
+        </p>
+        <p>
+            Enviem el rebuig, amb el detall del motiu de desacord que ens has indicat a través de la teva oficina virtual, a la distribuïdora.
+        </p>
+        <p>
+            Si es tracta d’un error en la comunicació per part de la distribuïdora ens faran arribar una nova comunicació corregida, si pel contrari es tracta d’un error a l’hora de fer el registre o de la comunicació per part de la Comunitat Autònoma cal que contacteu amb la mateixa per tal de modificar la informació i que comenci el procés novament.
+        </p>
+        <p>
+            Malauradament, la distribuïdora no ens indica si es tracta d’una o altra casuística pel que et recomanem que contactis directament amb la distribuïdora i el departament corresponent de la teva Comunitat Autònoma per aclarir-ho.
+        </p>
+        <p>
+            Qualsevol dubte seguim en contacte.
+        </p>
+	    Salutacions,<br>
+        <br>
+        Equip de Som Energia<br>
+        <a href="mailto:modifica@somenergia.coop">modifica@somenergia.coop</a><br>
+        <a href="http://www.somenergia.coop/ca">www.somenergia.coop</a>
+    </body>
+</%def>
+<%def name="correu_es()">
+    <body>
+        <table width="100%" frame="below" bgcolor="#E8F1D4">
+            <tr>
+                <td height=2px>
+                    <font size=2><strong> Contrato Som Energia nº ${polissa.name}</strong></font>
+                </td>
+                <td valign=top rowspan="4" align="right">
+                    <img width='130' height='65' src="https://www.somenergia.coop/wp-content/uploads/2014/11/logo-somenergia.png">
+                </td>
+            </tr>
+            <tr>
+                <td height=2px>
+                    <font size=1> Dirección del punto de suministro: ${object.cups_id.direccio}</font>
+                </td>
+            </tr>
+            <tr>
+                <td height=2px>
+                    <font size=1> Código CUPS: ${object.cups_id.name}</font>
+                </td>
+            </tr>
+        </table>
+        <p>
+            Hola${get_partner_name(object)},
+	    </p>
+        <p>
+	        Nos ha llegado la notificación que no estás de acuerdo con los datos que nos ha pasado la empresa de distribución eléctrica referente a tu instalación de autoconsumo asociada al CUPS ${object.cups_id.name} con dirección de suministro ${object.cups_id.direccio}.
+        </p>
+        <p>
+            Enviamos el rechazo, con el detalle del motivo de desacuerdo que nos has indicado a través de tu oficina virtual, a la distribuidora.
+        </p>
+        <p>
+            Si se trata de un error en la comunicación por parte de la distribuidora nos harán llegar una nueva comunicación corregida, si por el contrario se trata de un error a la hora de hacer el registro o de la comunicación por parte de la Comunidad Autónoma deberás ponerte en contacto con la misma a fin de modificar la información y que comience el proceso nuevamente.
+        </p>
+        <p>
+            Desgraciadamente, la distribuidora no nos indica si se trata de una u otra casuística por lo que te recomendamos que contactes directamente con la distribuidora y el departamento correspondiente de tu Comunidad Autónoma para aclararlo.
+        </p>
+        <p>
+            Cualquier duda seguimos en contacto.
+        </p>
+        Saludos,<br>
+        <br>
+        Equipo de Som Energia<br>
+        <a href="mailto:modifica@somenergia.coop">modifica@somenergia.coop</a><br>
+        <a href="http://www.somenergia.coop/es">www.somenergia.coop</a>
+    </body>
+</%def>

--- a/input/correu-notificacioRebuigAutoconsum.mako.yaml
+++ b/input/correu-notificacioRebuigAutoconsum.mako.yaml
@@ -1,0 +1,8 @@
+cc: false
+to: ${object.cups_polissa_id.direccio_notificacio.email}
+subject_translations:
+  ca_ES: Rebuig dades inst.autoproducció CUPS ${object.cups_id.name}
+  es_ES: Rechazo datos inst.autoproducción CUPS ${object.cups_id.name}
+subject: Rebuig dades inst.autoproducció CUPS ${object.cups_id.name} / Rechazo
+  datos inst.autoproducción CUPS ${object.cups_id.name}
+bcc: support.17062.b8d9f4469fa4d856@helpscout.net

--- a/input/correu-validacioDadesModificacio.mako
+++ b/input/correu-validacioDadesModificacio.mako
@@ -25,6 +25,13 @@ def get_tension_type(object_, pas1, lang):
         return THREEPHASE[lang]
     return MONOPHASE[lang]
 
+
+def get_autoconsum_description(object_, auto_consum, lang):
+    M101 = object_.pool.get('giscedata.switching.m1.01')
+    tipus_autoconsum = dict(M101.fields_get(object_._cr, object_._uid, context={'lang': lang})['tipus_autoconsum']['selection'])
+
+    return auto_consum + " - " + tipus_autoconsum[auto_consum]
+
 tipus_tensio = False
 if pas1:
 
@@ -51,6 +58,11 @@ if pas1:
     if pas1.solicitud_tensio == "S" and pas1.tensio_solicitada:
         lang = object.cups_polissa_id.titular.lang
         tipus_tensio = get_tension_type(object, pas1, lang)
+
+    nou_autoconsum = False
+    if object.cups_polissa_id.autoconsumo != pas1.tipus_autoconsum:
+        nou_autoconsum = get_autoconsum_description(object, pas1.tipus_autoconsum, object.cups_polissa_id.titular.lang)
+
 %>
 
 <!doctype html>
@@ -102,6 +114,9 @@ if pas1:
         %if tipus_tensio:
         - Tensió desitjada: ${tipus_tensio}
         %endif
+        %if nou_autoconsum:
+        - Autoconsum desitjat: ${nou_autoconsum}
+        %endif
     </p>
     <p>
         Telèfon de contacte: ${cont_telefon} (recorda que aquest telèfon l'utilitzarà la distribuïdora de la teva zona per posar-se en contacte amb tu en el cas que sigui necessari).
@@ -146,6 +161,9 @@ if pas1:
         %endif
         %if tipus_tensio:
         - Tensión deseada: ${tipus_tensio}
+        %endif
+        %if nou_autoconsum:
+        - Autoconsumo deseado: ${nou_autoconsum}
         %endif
     </p>
     <p>

--- a/testcases.yaml
+++ b/testcases.yaml
@@ -777,7 +777,15 @@
 #    es_auto_tit_diff: 282561
 #    ca_noauto: 282878
 #    es_noauto: 281207
-#
+
+#notificacioRebuigAutoconsum:
+#  template: input/correu-notificacioRebuigAutoconsum.mako
+#  model: giscedata.switching
+#  poweremailId: som_switching.email_atr_rebuig_d1_01
+#  cases:
+#    ca: 304316
+#    es: 300707
+
 #peticioDocumentacioSubministres:
 #  template: input/correu-peticioDocumentacioSubministres.mako
 #  model: res.partner


### PR DESCRIPTION
S'ha modificat les plantilles de:

- Notificació d'alta d'autoconsum (D101): s'eliminen les dades sobre l'autoconsum i s'informa de com validar les dades des de l'OV (enllaç per determinar)
- Validació dades modificació (M101): es mostren només els camps de solicitud que suposen un canvi, i s'afegeix la informació sobre l'autoconsum si s'escau.

A més, s'ha creat una nova plantilla de Notificació Rebuig autoconsum, per tal de notificar quan s'ha rebut el rebuig del D101 fet a través de la OV.