### PR TITLE
Modify support to reject templates 

### DIFF
--- a/oomako
+++ b/oomako
@@ -122,6 +122,8 @@ def renderMako(template, model, id, data, uid=1):
         #browse last param is OpenERP dict Context. The 'browse_reference' variable to True
         #force get all references in object (even one2many fields)
         ir_data_obj = pool.get('ir.model.data')
+        if isinstance(id, dict):
+            id = id['id']
         if not isinstance(id, int):
             try:
                 id_data = ir_data_obj.search(cursor, uid, [('module', '=', id.split('.')[0]), ('name', '=', id.split('.')[1])])
@@ -226,8 +228,14 @@ def makeB2bTestCase(testCaseName, id) :
         self.maxDiff = data.get('maxDiff', None)
 
         if 'rejectId' in self.fixture:
-            output = renderMakoReject(
+            output_reject = renderMakoReject(
                 self.fixture.template,
+                self.fixture.model,
+                id,
+                data)
+            data['notificacio_text'] = output_reject
+            output = renderMako(
+                self.fixture.main_template,
                 self.fixture.model,
                 id,
                 data)

--- a/testcases.yaml
+++ b/testcases.yaml
@@ -519,6 +519,7 @@
 #rebuig03NifNoCoincide:
 #    template: input/rebutjos/rebuig03.mako
 #    model: giscedata.switching
+#    main_template: input/correu-rebuigC102.mako
 #    rejectId: 1234
 #    cases:
 #        es:
@@ -527,6 +528,15 @@
 #        ca:
 #            id: 723
 #            pas: 1
+rebuigM102_E7:
+    template: input/rebutjos/rebuigM102_E7.mako
+    model: giscedata.switching
+    main_template: input/correu-rebuigM102.mako
+    rejectId: 90
+    cases:
+        ca:
+            id: 364807
+            pas: 1
 #
 # rebuigC102:
 #   template: input/correu-rebuigC102.mako


### PR DESCRIPTION
Modify support to reject templates  and composite poweremail.templates with reject message

With this modification, you can test your reject templates together with the main template. In testcase.yaml, add:

```
rebuigM102_E7:
    template: input/rebutjos/rebuigM102_E7.mako
    model: giscedata.switching
    main_template: input/correu-rebuigM102.mako
    rejectId: notification_atr_M104_E7
    cases:
        ca:
            id: 364807
            pas: 1
```
Where:
*  input/rebutjos/rebuigM102_E7.mako -> is your "reject" message template (model giscedata.switching.notify)
* main_template: is your "poweremail.template"
* rejectId is ir.model.data (numeric id or semantic id)
* cases: id you want to test (in this example, giscedata.switching id)