### PR TITLE
🐛 fix: mask bank account numbers in outgoing emails

### DIFF
--- a/input/correu-facturaRetornadaGenerationKWh.mako
+++ b/input/correu-facturaRetornadaGenerationKWh.mako
@@ -2,7 +2,7 @@
 % if object.partner_id.lang != "ca_ES":
 Saludos ${object.partner_id.name},
 
-El banco nos ha devuelto el recibo del Generation kWh XXGKWHXXX que nos realizaste el ${object.date_invoice} a la cuenta ${(object.partner_bank.acc_number or '').replace(' ', '')[-4:].rjust(len((object.partner_bank.acc_number or '').replace(' ', '')), '*')}
+El banco nos ha devuelto el recibo del Generation kWh XXGKWHXXX que nos realizaste el ${object.date_invoice} a la cuenta ${(object.partner_bank.iban or '')[-4:].rjust(len(object.partner_bank.iban or ''), '*')}
  
 Te agradecemos que nos indiques como hacer el pago.
 
@@ -18,7 +18,7 @@ www.somenergia.coop
 % if object.partner_id.lang != "es_ES":
 Salutacions ${object.partner_id.name},
 
-El banc ens ha retornart el rebut del Generartion kWh XXGKWHXXX que ens vas fer el ${object.date_invoice} al compte ${(object.partner_bank.acc_number or '').replace(' ', '')[-4:].rjust(len((object.partner_bank.acc_number or '').replace(' ', '')), '*')}
+El banc ens ha retornart el rebut del Generartion kWh XXGKWHXXX que ens vas fer el ${object.date_invoice} al compte ${(object.partner_bank.iban or '')[-4:].rjust(len(object.partner_bank.iban or ''), '*')}
 
 T'agraim que ens indiquis com fer el pagament.
 

--- a/input/correu-facturaRetornadaGenerationKWh.mako
+++ b/input/correu-facturaRetornadaGenerationKWh.mako
@@ -2,7 +2,7 @@
 % if object.partner_id.lang != "ca_ES":
 Saludos ${object.partner_id.name},
 
-El banco nos ha devuelto el recibo del Generation kWh XXGKWHXXX que nos realizaste el ${object.date_invoice} a la cuenta ${(object.partner_bank.acc_number or '').replace(' ', '-')}
+El banco nos ha devuelto el recibo del Generation kWh XXGKWHXXX que nos realizaste el ${object.date_invoice} a la cuenta ${(object.partner_bank.acc_number or '').replace(' ', '')[-4:].rjust(len((object.partner_bank.acc_number or '').replace(' ', '')), '*')}
  
 Te agradecemos que nos indiques como hacer el pago.
 
@@ -18,7 +18,7 @@ www.somenergia.coop
 % if object.partner_id.lang != "es_ES":
 Salutacions ${object.partner_id.name},
 
-El banc ens ha retornart el rebut del Generartion kWh XXGKWHXXX que ens vas fer el ${object.date_invoice} al compte ${(object.partner_bank.acc_number or '').replace(' ', '-')}
+El banc ens ha retornart el rebut del Generartion kWh XXGKWHXXX que ens vas fer el ${object.date_invoice} al compte ${(object.partner_bank.acc_number or '').replace(' ', '')[-4:].rjust(len((object.partner_bank.acc_number or '').replace(' ', '')), '*')}
 
 T'agraim que ens indiquis com fer el pagament.
 

--- a/input/correu-generationKWhAmortitzacio.mako
+++ b/input/correu-generationKWhAmortitzacio.mako
@@ -28,7 +28,7 @@ nominal_amount = investment_obj[0]['nshares']*100
 amount_amortization = nominal_amount*4/100
 num_amortization = int(investment_obj[0]['amortized_amount']/amount_amortization)
 partner_bank = object.partner_bank.iban
-bank_account = ' '.join(partner_bank[i:i+4] for i in xrange(0,len(partner_bank),4))
+bank_account = partner_bank[-4:].rjust(len(partner_bank), '*')
 
 Invoice = object.pool.get('account.invoice')
 invoice_obj = Invoice.browse(object._cr, object._uid, object.id)

--- a/input/correu-liquidacioApoPas1.mako
+++ b/input/correu-liquidacioApoPas1.mako
@@ -4,7 +4,7 @@
 
 <%
 partner_bank = object.partner_bank.iban
-iban = ' '.join(partner_bank[i:i+4] for i in xrange(0,len(partner_bank),4))
+iban = partner_bank[-4:].rjust(len(partner_bank), '*')
 %>
 
 % if object.partner_id.lang != "es_ES":

--- a/input/correu-liquidacioAportacioVoluntaria.mako
+++ b/input/correu-liquidacioAportacioVoluntaria.mako
@@ -3,7 +3,7 @@
 <img src="https://www.somenergia.coop/wp-content/uploads/2014/07/logo.png"
 <%
 partner_bank = object.invoice_id.partner_bank.iban
-iban = ' '.join(partner_bank[i:i+4] for i in xrange(0,len(partner_bank),4))
+iban = partner_bank[-4:].rjust(len(partner_bank), '*')
 %>
 <%
 from mako.template import Template

--- a/input/correu-liquidacioTitolsParticipatius.mako
+++ b/input/correu-liquidacioTitolsParticipatius.mako
@@ -41,7 +41,7 @@ Titular: ${object.partner_id.name}<br />
 Període del ${object.invoice_id.invoice_line[0].name.split(' ')[1]} al ${object.invoice_id.invoice_line[-1].name.split(' ')[3]}<br />
 <strong>Import total: ${object.invoice_id.amount_total}€</strong><br />
 <br />
-Núm. IBAN: ${(object.invoice_id.partner_bank.iban or '')}<br />
+Núm. IBAN: ${(object.invoice_id.partner_bank.iban or '')[-4:].rjust(len(object.invoice_id.partner_bank.iban or ''), '*')}<br />
 <br />
 Aprofitem per agrair-te una vegada més la teva implicació amb el nostre projecte.<br />
 <br />
@@ -71,7 +71,7 @@ Titular: ${object.partner_id.name}<br />
 Período del ${object.invoice_id.invoice_line[0].name.split(' ')[1]} al ${object.invoice_id.invoice_line[-1].name.split(' ')[3]}<br />
 <strong>Importe total: ${object.invoice_id.amount_total}€</strong><br />
 <br />
-Nº IBAN: ${(object.invoice_id.partner_bank.iban or '')}<br />
+Nº IBAN: ${(object.invoice_id.partner_bank.iban or '')[-4:].rjust(len(object.invoice_id.partner_bank.iban or ''), '*')}<br />
 <br />
 Aprovechamos para agradecerte una vez más tu implicación con nuestro proyecto.<br />
 <br />

--- a/input/correu-resumAmortitzacioGenerationKWh.mako
+++ b/input/correu-resumAmortitzacioGenerationKWh.mako
@@ -7,7 +7,7 @@ codiGenKkh = "GKWHXXX" # TODO obtain from erp
 dataInversioISO = "2017-05-30" # TODO obtain from erp
 pagamentNum = "1 de 24"
 importTotal = object.amount_total
-numCuenta = (object.partner_bank.acc_number or '').replace(' ', '')[-4:].rjust(len((object.partner_bank.acc_number or '').replace(' ', '')), '*')
+numCuenta = (object.invoice_id.partner_bank.iban or '')[-4:].rjust(len(object.invoice_id.partner_bank.iban or ''), '*')
 
 dataInversio = datetime.datetime.strptime(dataInversioISO,"%Y-%m-%d").strftime("%d/%m/%Y")
 

--- a/input/correu-resumAmortitzacioGenerationKWh.mako
+++ b/input/correu-resumAmortitzacioGenerationKWh.mako
@@ -7,7 +7,7 @@ codiGenKkh = "GKWHXXX" # TODO obtain from erp
 dataInversioISO = "2017-05-30" # TODO obtain from erp
 pagamentNum = "1 de 24"
 importTotal = object.amount_total
-numCuenta = (object.partner_bank.acc_number or '').replace(' ', '-')
+numCuenta = (object.partner_bank.acc_number or '').replace(' ', '')[-4:].rjust(len((object.partner_bank.acc_number or '').replace(' ', '')), '*')
 
 dataInversio = datetime.datetime.strptime(dataInversioISO,"%Y-%m-%d").strftime("%d/%m/%Y")
 


### PR DESCRIPTION
## Summary
- Mask bank account values in Generation kWh and liquidation email templates so only the last digits are visible.
- Standardize masking style to match the existing `[-4:].rjust(len(...), '*')` pattern used in the project.
- Prevent exposing full IBAN/account numbers in outgoing communication templates.

## Files changed
- `input/correu-generationKWhAmortitzacio.mako`
- `input/correu-liquidacioAportacioVoluntaria.mako`
- `input/correu-liquidacioTitolsParticipatius.mako`
- `input/correu-liquidacioApoPas1.mako`
- `input/correu-facturaRetornadaGenerationKWh.mako`
- `input/correu-resumAmortitzacioGenerationKWh.mako`